### PR TITLE
Switch to x/sys/execabs for windows security fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/lucor/goinfo
 
 go 1.13
 
-require golang.org/x/mod v0.4.2
+require (
+	golang.org/x/mod v0.4.2
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lucor/goinfo
 
 go 1.13
 
-require golang.org/x/mod v0.2.0
+require golang.org/x/mod v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
-golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/report/go_env.go
+++ b/report/go_env.go
@@ -3,9 +3,9 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"github.com/lucor/goinfo"
+	"golang.org/x/sys/execabs"
 )
 
 // GoEnv collects the info about the Go environment using the go env tool
@@ -21,7 +21,7 @@ func (i *GoEnv) Summary() string {
 // Info returns the collected info
 func (i *GoEnv) Info() (goinfo.Info, error) {
 	var info goinfo.Info
-	cmd := exec.Command("go", "env", "-json")
+	cmd := execabs.Command("go", "env", "-json")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("could not detect go env info: %w", err)

--- a/report/go_module.go
+++ b/report/go_module.go
@@ -5,12 +5,12 @@ import (
 	"go/build"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/lucor/goinfo"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/sys/execabs"
 )
 
 const (
@@ -120,7 +120,7 @@ func vcsInfo(workDir string) (string, error) {
 
 // gitInfo returns the "human-readable" commit name using git describe
 func gitInfo(workDir string) (string, error) {
-	cmd := exec.Command("git", "describe", "--tags", "--dirty", "--always")
+	cmd := execabs.Command("git", "describe", "--tags", "--dirty", "--always")
 	cmd.Dir = workDir
 	out, err := cmd.CombinedOutput()
 	s := strings.Trim(string(out), "\n")

--- a/report/go_version.go
+++ b/report/go_version.go
@@ -2,10 +2,10 @@ package report
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/lucor/goinfo"
+	"golang.org/x/sys/execabs"
 )
 
 // GoVersion collects the info about the Go version using the go version command
@@ -18,7 +18,7 @@ func (i *GoVersion) Summary() string {
 
 // Info returns the collected info
 func (i *GoVersion) Info() (goinfo.Info, error) {
-	cmd := exec.Command("go", "version")
+	cmd := execabs.Command("go", "version")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("could not detect go version info: %w", err)

--- a/report/os_darwin.go
+++ b/report/os_darwin.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/lucor/goinfo"

--- a/report/os_windows.go
+++ b/report/os_windows.go
@@ -4,15 +4,15 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/lucor/goinfo"
+	"golang.org/x/sys/execabs"
 )
 
 // Info returns the collected info about the OS
 func (i *OS) Info() (goinfo.Info, error) {
-	cmd := exec.Command("cmd", "/C", "wmic os get /value")
+	cmd := execabs.Command("cmd", "/C", "wmic os get /value")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("could not detect os info using wmic command: %w", err)

--- a/report/os_xdg.go
+++ b/report/os_xdg.go
@@ -7,11 +7,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/lucor/goinfo"
+	"golang.org/x/sys/execabs"
 )
 
 // Info returns the collected info
@@ -79,7 +79,7 @@ func (i *OS) parseOsReleaseCmdOutput(data []byte) (goinfo.Info, error) {
 }
 
 func (i *OS) architecture() (string, error) {
-	cmd := exec.Command("uname", "-m")
+	cmd := execabs.Command("uname", "-m")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("could not detect architecture using uname command: %w", err)
@@ -91,7 +91,7 @@ func (i *OS) architecture() (string, error) {
 }
 
 func (i *OS) kernel() (string, error) {
-	cmd := exec.Command("uname", "-rsv")
+	cmd := execabs.Command("uname", "-rsv")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("could not detect the kernel using uname command: %w", err)


### PR DESCRIPTION
The os/exec package on Windows will match the behaviour of cmd.exe by considering the local folder as a primary part of the path. This means that a malicious binary with the same name, in the current folder, would be run instead of the expected binary in the system path. Due to the backwards compat being an issue, this could not be fixed within ox/exec before Go v2. See https://blog.golang.org/path-security for more info.

This should not change any behaviour for anything else than Windows platforms. I have switched everything to use the new package for the sake of consistency and avoiding to compile two very similar packages into the binary.